### PR TITLE
メディアボタンによる操作に対応

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -76,7 +76,17 @@
         </provider>
         <service android:name=".ForegroundService" android:stopWithTask="true"
             android:foregroundServiceType="mediaPlayback"
-            />
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </service>
+        <receiver android:name="androidx.media.session.MediaButtonReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
         <meta-data
             android:name="com.google.android.gms.ads.APPLICATION_ID"
             android:value="ca-app-pub-9499594730627438~9516019647"/>


### PR DESCRIPTION
以下のメディアボタンによる操作に対応
・再生/停止ボタン
・次の曲へ
・前の曲へ

■動確した端末
Pixel3a + API34 (エミュレータ)
Pixel6   + API30 (エミュレータ)
PixelXL + API22 (エミュレータ)
Rakuten mini + API 28 (実機)

■動確内容
・エミュレータ
adbによる再生/停止ボタンの動作
adb shell input keyevent KEYCODE_MEDIA_PLAY
adb shell input keyevent KEYCODE_MEDIA_PAUSE

・実機
有線イヤホンによる再生/停止ボタンの動作
Bluetoothイヤホンによる再生/停止ボタン、次の曲へボタン、前の曲へボタンの動作

Close #139

![image](https://github.com/ryotayama/Hayaemon_Android/assets/32073583/bc1adfc5-b9da-40cc-8b21-c0a02986e46f)
